### PR TITLE
Fix #70; allow custom callbacks on download() and add()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Added
+
+* `progress_handler` parameter to `wn.download()` ([#70])
+* `progress_handler` parameter to `wn.add()` ([#70])
+
 ### Changed
 
 * Renamed `lgcode` parameter to `lang` throughout ([#66])
@@ -60,3 +65,4 @@ abandoned, but this is an entirely new codebase.
 [#60]: https://github.com/goodmami/wn/issues/60
 [#61]: https://github.com/goodmami/wn/issues/61
 [#66]: https://github.com/goodmami/wn/issues/66
+[#70]: https://github.com/goodmami/wn/issues/70

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+* `add` parameter to `wn.download()` ([#73])
+* `--no-add` option to `wn download` command ([#73])
 * `progress_handler` parameter to `wn.download()` ([#70])
 * `progress_handler` parameter to `wn.add()` ([#70])
 
@@ -66,3 +68,4 @@ abandoned, but this is an entirely new codebase.
 [#61]: https://github.com/goodmami/wn/issues/61
 [#66]: https://github.com/goodmami/wn/issues/66
 [#70]: https://github.com/goodmami/wn/issues/70
+[#73]: https://github.com/goodmami/wn/issues/73

--- a/wn/__main__.py
+++ b/wn/__main__.py
@@ -8,7 +8,7 @@ def _download(args):
     if args.index:
         wn.config.load_index(args.index)
     for target in args.target:
-        wn.download(target)
+        wn.download(target, add=args.add)
 
 
 def _lexicons(args):
@@ -67,6 +67,10 @@ parser_download.add_argument(
 )
 parser_download.add_argument(
     '--index', type=_file_path_type, help='project index to use for downloading'
+)
+parser_download.add_argument(
+    '--no-add', action='store_false', dest='add',
+    help='download and cache without adding to the database'
 )
 parser_download.set_defaults(func=_download)
 

--- a/wn/_db.py
+++ b/wn/_db.py
@@ -185,13 +185,13 @@ def add(source: AnyPath, progress_handler=get_progress_handler) -> None:
     indicates the total number of rows to insert.
 
     """
-    callback = get_progress_handler(progress_handler, 'Database', 'rows', '')
-    callback(0, status='Inspecting')
     for project in iterpackages(source):
-        _add_lmf(project.resource_file(), callback)
+        _add_lmf(project.resource_file(), progress_handler)
 
 
-def _add_lmf(source, callback):
+def _add_lmf(source, progress_handler):
+    callback = get_progress_handler(progress_handler, 'Database', '\b', '')
+
     with _connect() as conn:
         cur = conn.cursor()
         # abort if any lexicon in *source* is already added
@@ -238,7 +238,7 @@ def _add_lmf(source, callback):
                          'Synset', 'Definition',  # 'ILIDefinition',
                          'SynsetRelation'))
             count += counts.get('Synset', 0)  # again for ILIs
-            callback(0, max=count)
+            callback(0, count=0, max=count)
 
             synsets = lexicon.synsets
             entries = lexicon.lexical_entries

--- a/wn/_db.py
+++ b/wn/_db.py
@@ -12,7 +12,7 @@ import sqlite3
 
 import wn
 from wn._types import AnyPath
-from wn._util import ProgressBar, resources, short_hash
+from wn._util import get_progress_handler, resources, short_hash
 from wn.project import iterpackages
 from wn import constants
 from wn import lmf
@@ -161,22 +161,37 @@ def is_schema_compatible(create: bool = False) -> bool:
         return True
 
 
-def add(source: AnyPath) -> None:
+def add(source: AnyPath, progress_handler=get_progress_handler) -> None:
     """Add the LMF file at *source* to the database.
 
     The file at *source* may be gzip-compressed or plain text XML.
 
     >>> wn.add('english-wordnet-2020.xml')
-    Checking english-wordnet-2020.xml
-    Reading english-wordnet-2020.xml
-    Building [###############################] (1337590/1337590)
+    Added ewn:2020 (English WordNet)
+
+    The *progress_handler* parameter takes a callable that is called
+    after every block of rows is inserted. The handler function
+    should have the following signature:
+
+    .. code-block:: python
+
+       def progress_handler(n: int, **kwargs) -> str:
+           ...
+
+    The *n* parameter is the number of rows last inserted into the
+    database.  A ``status`` key on the *kwargs* indicates the current
+    status of adding the lexicon (``Inspecting``, ``ILI``, ``Synset``,
+    etc.). After inspecting the file, a ``max`` keyword on *kwargs*
+    indicates the total number of rows to insert.
 
     """
+    callback = get_progress_handler(progress_handler, 'Database', 'rows', '')
+    callback(0, status='Inspecting')
     for project in iterpackages(source):
-        _add_lmf(project.resource_file())
+        _add_lmf(project.resource_file(), callback)
 
 
-def _add_lmf(source):
+def _add_lmf(source, callback):
     with _connect() as conn:
         cur = conn.cursor()
         # abort if any lexicon in *source* is already added
@@ -223,32 +238,28 @@ def _add_lmf(source):
                          'Synset', 'Definition',  # 'ILIDefinition',
                          'SynsetRelation'))
             count += counts.get('Synset', 0)  # again for ILIs
-            indicator = ProgressBar(
-                max=count,
-                fmt='\rBuilding: [{fill:<{width}}] ({count}/{max}) {type}',
-                type='',
-            )
+            callback(0, max=count)
 
             synsets = lexicon.synsets
             entries = lexicon.lexical_entries
 
-            _insert_ilis(synsets, cur, indicator)
-            _insert_synsets(synsets, lexid, cur, indicator)
-            _insert_entries(entries, lexid, cur, indicator)
-            _insert_forms(entries, lexid, cur, indicator)
-            _insert_senses(entries, lexid, cur, indicator)
+            _insert_ilis(synsets, cur, callback)
+            _insert_synsets(synsets, lexid, cur, callback)
+            _insert_entries(entries, lexid, cur, callback)
+            _insert_forms(entries, lexid, cur, callback)
+            _insert_senses(entries, lexid, cur, callback)
 
-            _insert_synset_relations(synsets, lexid, cur, indicator)
+            _insert_synset_relations(synsets, lexid, cur, callback)
             _insert_sense_relations(entries, lexid, 'sense_relations',
-                                    sense_ids, cur, indicator)
+                                    sense_ids, cur, callback)
             _insert_sense_relations(entries, lexid, 'sense_synset_relations',
-                                    synset_ids, cur, indicator)
+                                    synset_ids, cur, callback)
 
-            _insert_synset_definitions(synsets, lexid, cur, indicator)
+            _insert_synset_definitions(synsets, lexid, cur, callback)
             _insert_examples([sense for entry in entries for sense in entry.senses],
-                             lexid, 'sense_examples', cur, indicator)
-            _insert_examples(synsets, lexid, 'synset_examples', cur, indicator)
-            indicator.update(0, type='')  # clear type string
+                             lexid, 'sense_examples', cur, callback)
+            _insert_examples(synsets, lexid, 'synset_examples', cur, callback)
+            callback(0, status='')  # clear type string
 
             print(f'\r\033[KAdded {lexicon.id}:{lexicon.version} ({lexicon.label})',
                   file=sys.stderr)
@@ -274,8 +285,8 @@ def _split(sequence):
     yield sequence[i:]
 
 
-def _insert_ilis(synsets, cur, indicator):
-    indicator.update(0, type='ILI')
+def _insert_ilis(synsets, cur, callback):
+    callback(0, status='ILI')
     for batch in _split(synsets):
         data = (
             (synset.ili,
@@ -284,11 +295,11 @@ def _insert_ilis(synsets, cur, indicator):
             for synset in batch if synset.ili and synset.ili != 'in'
         )
         cur.executemany('INSERT OR IGNORE INTO ilis VALUES (?,?,?)', data)
-        indicator.update(len(batch))
+        callback(len(batch))
 
 
-def _insert_synsets(synsets, lex_id, cur, indicator):
-    indicator.update(0, type='Synsets')
+def _insert_synsets(synsets, lex_id, cur, callback):
+    callback(0, status='Synsets')
     query = f'INSERT INTO synsets VALUES (null,?,?,?,({POS_QUERY}),?,?)'
     for batch in _split(synsets):
         data = (
@@ -302,11 +313,11 @@ def _insert_synsets(synsets, lex_id, cur, indicator):
             for synset in batch
         )
         cur.executemany(query, data)
-        indicator.update(len(batch))
+        callback(len(batch))
 
 
-def _insert_synset_definitions(synsets, lexid, cur, indicator):
-    indicator.update(0, type='Definitions')
+def _insert_synset_definitions(synsets, lexid, cur, callback):
+    callback(0, status='Definitions')
     query = f'INSERT INTO definitions VALUES (({SYNSET_QUERY}),?,?,?)'
     for batch in _split(synsets):
         data = [
@@ -320,11 +331,11 @@ def _insert_synset_definitions(synsets, lexid, cur, indicator):
             for definition in synset.definitions
         ]
         cur.executemany(query, data)
-        indicator.update(len(data))
+        callback(len(data))
 
 
-def _insert_synset_relations(synsets, lexid, cur, indicator):
-    indicator.update(0, type='Synset Relations')
+def _insert_synset_relations(synsets, lexid, cur, callback):
+    callback(0, status='Synset Relations')
     type_query = 'SELECT r.rowid FROM synset_relation_types AS r WHERE r.type = ?'
     query = f'''
         INSERT INTO synset_relations
@@ -343,11 +354,11 @@ def _insert_synset_relations(synsets, lexid, cur, indicator):
             for relation in synset.relations
         ]
         cur.executemany(query, data)
-        indicator.update(len(data))
+        callback(len(data))
 
 
-def _insert_entries(entries, lex_id, cur, indicator):
-    indicator.update(0, type='Words')
+def _insert_entries(entries, lex_id, cur, callback):
+    callback(0, status='Words')
     query = f'INSERT INTO entries VALUES (null,?,?,({POS_QUERY}),?)'
     for batch in _split(entries):
         data = (
@@ -358,11 +369,11 @@ def _insert_entries(entries, lex_id, cur, indicator):
             for entry in batch
         )
         cur.executemany(query, data)
-        indicator.update(len(batch))
+        callback(len(batch))
 
 
-def _insert_forms(entries, lexid, cur, indicator):
-    indicator.update(0, type='Word Forms')
+def _insert_forms(entries, lexid, cur, callback):
+    callback(0, status='Word Forms')
     query = f'INSERT INTO forms VALUES (null,({ENTRY_QUERY}),?,?,?)'
     for batch in _split(entries):
         forms = []
@@ -371,11 +382,11 @@ def _insert_forms(entries, lexid, cur, indicator):
             forms.extend((entry.id, lexid, form.form, form.script, i)
                          for i, form in enumerate(entry.forms, 1))
         cur.executemany(query, forms)
-        indicator.update(len(forms))
+        callback(len(forms))
 
 
-def _insert_senses(entries, lexid, cur, indicator):
-    indicator.update(0, type='Senses')
+def _insert_senses(entries, lexid, cur, callback):
+    callback(0, status='Senses')
     query = f'''
         INSERT INTO senses
         VALUES (null,
@@ -402,11 +413,11 @@ def _insert_senses(entries, lexid, cur, indicator):
             for i, sense in enumerate(entry.senses)
         ]
         cur.executemany(query, data)
-        indicator.update(len(data))
+        callback(len(data))
 
 
-def _insert_sense_relations(entries, lexid, table, ids, cur, indicator):
-    indicator.update(0, type='Sense Relations')
+def _insert_sense_relations(entries, lexid, table, ids, cur, callback):
+    callback(0, status='Sense Relations')
     target_query = SENSE_QUERY if table == 'sense_relations' else SYNSET_QUERY
     type_query = 'SELECT r.rowid FROM sense_relation_types AS r WHERE r.type = ?'
     query = f'''
@@ -428,11 +439,11 @@ def _insert_sense_relations(entries, lexid, table, ids, cur, indicator):
         ]
         # be careful of SQL injection here
         cur.executemany(query, data)
-        indicator.update(len(data))
+        callback(len(data))
 
 
-def _insert_examples(objs, lexid, table, cur, indicator):
-    indicator.update(0, type='Examples')
+def _insert_examples(objs, lexid, table, cur, callback):
+    callback(0, status='Examples')
     query = f'INSERT INTO {table} VALUES (({SYNSET_QUERY}),?,?,?)'
     for batch in _split(objs):
         data = [
@@ -445,7 +456,7 @@ def _insert_examples(objs, lexid, table, cur, indicator):
         ]
         # be careful of SQL injection here
         cur.executemany(query, data)
-        indicator.update(len(data))
+        callback(len(data))
 
 
 def remove(lexicon: str) -> None:

--- a/wn/_download.py
+++ b/wn/_download.py
@@ -3,7 +3,7 @@ import sys
 
 import requests
 
-from wn._util import ProgressBar, is_url
+from wn._util import get_progress_handler, is_url
 from wn import _db
 from wn import config
 
@@ -12,7 +12,7 @@ CHUNK_SIZE = 8 * 1024  # how many KB to read at a time
 TIMEOUT = 10  # number of seconds to wait for a server response
 
 
-def download(project_or_url: str) -> None:
+def download(project_or_url: str, progress_handler=get_progress_handler) -> None:
     """Download the wordnet specified by *project_or_url*.
 
     If *project_or_url* starts with `'http://'` or `'https://'`, then
@@ -27,10 +27,23 @@ def download(project_or_url: str) -> None:
     will be used instead.
 
     >>> wn.download('ewn:2020')
-    Download complete (13643357 bytes)
-    Checking /tmp/tmp_uqntl0l.xml
-    Reading /tmp/tmp_uqntl0l.xml
-    Building [###############################] (1337590/1337590)
+    Added ewn:2020 (English WordNet)
+
+    The *progress_handler* parameter takes a callable that is called
+    after every chunk of bytes is received. The handler function
+    should have the following signature:
+
+    .. code-block:: python
+
+       def progress_handler(n: int, **kwargs) -> str:
+           ...
+
+    The *n* parameter is the number of bytes received in a chunk. When
+    a request is sent, the handler function is called with ``max`` key
+    in *kwargs* mapped to the total number of bytes (taken from the
+    response's ``Content-Length`` header). A ``status`` key may also
+    indicate the current status (``Requesting``, ``Receiving``,
+    ``Completed``).
 
     """
     if is_url(project_or_url):
@@ -40,19 +53,24 @@ def download(project_or_url: str) -> None:
         url = info['resource_url']
 
     path = config.get_cache_path(url)
+
     if path.exists():
         print(f'Cached file found: {path!s}', file=sys.stderr)
+
     else:
+        callback = get_progress_handler(progress_handler, 'Download', 'bytes', '')
+        size: int = 0
         try:
             with open(path, 'wb') as f:
+                callback(0, status='Requesting')
                 with requests.get(url, stream=True, timeout=TIMEOUT) as response:
                     size = int(response.headers.get('Content-Length', 0))
-                    indicator = ProgressBar('Downloading ', max=size)
+                    callback(0, max=size, status='Receiving')
                     for chunk in response.iter_content(chunk_size=CHUNK_SIZE):
                         if chunk:
                             f.write(chunk)
-                        indicator.update(len(chunk))
-                    print(f'\r\x1b[KDownload complete ({size} bytes)', file=sys.stderr)
+                        callback(len(chunk))
+                    callback(0, status='Complete')
         except:  # noqa: E722 (exception is reraised)
             print(f'\r\x1b[KDownload failed at {size} bytes', file=sys.stderr)
             path.unlink()


### PR DESCRIPTION
Inspired by #67, this tries to make it easier for people to override the default behavior of progress bars. The default is as it was (a few aesthetic changes notwithstanding) but now `wn.download()` and `wn.add()` can take a `progress_handler` parameter set to `None` to disable the progress bars or to a custom function, e.g., for updating a GUI.

- Make ProgressBar easier to override
- Add `progress_handler` parameter to wn.download()
- Add `progress_handler` parameter to wn.add()
