### PR TITLE
Fix #181 Add OEWN 2022 to the index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Index
+
+* Added `oewn:2022` ([#181])
+
 
 ## [v0.9.3]
 
@@ -615,3 +619,4 @@ abandoned, but this is an entirely new codebase.
 [#168]: https://github.com/goodmami/wn/issues/168
 [#169]: https://github.com/goodmami/wn/issues/169
 [#177]: https://github.com/goodmami/wn/issues/177
+[#181]: https://github.com/goodmami/wn/issues/181

--- a/wn/index.toml
+++ b/wn/index.toml
@@ -10,6 +10,11 @@
   label = "Open English WordNet"
   language = "en"
   license = "https://creativecommons.org/licenses/by/4.0/"
+  [oewn.versions.2022]
+    url = """
+      https://en-word.net/static/english-wordnet-2022.xml.gz
+      https://github.com/globalwordnet/english-wordnet/releases/download/2022-edition/english-wordnet-2022.xml.gz
+    """
   [oewn.versions.2021]
     url = "https://en-word.net/static/english-wordnet-2021.xml.gz"
   [oewn.versions.2020]


### PR DESCRIPTION
This adds a link and a mirror for downloading the OEWN 2022 lexicon.

**Note:** there is currently an issue with the upstream files (https://github.com/globalwordnet/english-wordnet/issues/902), so don't merge this until it is fixed.