### PR TITLE
Added workflow to let contributors self-assign issues

### DIFF
--- a/.github/workflows/selfassign.yml
+++ b/.github/workflows/selfassign.yml
@@ -1,0 +1,24 @@
+# Allow users to automatically tag themselves to issues
+#
+# Usage:
+#  - a github user (a member of the repo) needs to comment
+#    with "#self-assign" on an issue to be assigned to them.
+#------------------------------------------------------------
+
+name: Self-assign
+on:
+  issue_comment:
+    types: created
+jobs:
+  one:
+    runs-on: ubuntu-latest
+    if: >-
+      (github.event.comment.body == '#take' ||
+       github.event.comment.body == '#self-assign')
+    steps:
+      - run: |
+          echo "Assigning issue ${{ github.event.issue.number }} to ${{ github.event.comment.user.login }}"
+          curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+               -d '{"assignees": ["${{ github.event.comment.user.login }}"]}' \
+                  https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/assignees
+          echo "Done 🔥 "


### PR DESCRIPTION
## Summary

Adding the self-assign workflow to allow contributors self-assign repository issues.

## Description

Commenting `#self-assign` in any issue will let repository members to self-assign that issue to themselves.

:point_right: This reduces chores for repo-maintainer(s).

## Motivation and Context

**Why is this change required? What problem does it solve?**

- :tada: This reduces some administrative overhead and makes it quicker for any contributor to self-assign an issue and start working on it.

- [x] I have raised an issue to propose this change
  - Closes #185  
