### PR TITLE
Lint Python code with ruff

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ Thanks for helping to make Wn better!
 - Testing automation: [nox](https://nox.thea.codes)
 - Unit/regression testing: [pytest](https://pytest.org/)
 - Packaging framework: [Flit](https://flit.readthedocs.io/en/latest/)
-- Coding style: [PEP-8](https://www.python.org/dev/peps/pep-0008/) (via [Flake8](https://flake8.pycqa.org/))
+- Coding style: [PEP-8](https://www.python.org/dev/peps/pep-0008/) (via [Ruff](https://beta.ruff.rs/docs/))
 - Type checking: [Mypy](http://mypy-lang.org/)
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -4,7 +4,7 @@ import nox
 @nox.session
 def lint(session):
     session.install('.[test,web]')
-    session.run('flake8', '--max-line-length', '88', 'wn', 'tests')
+    session.run('ruff', '.')
     session.run('mypy', '--python-version', '3.7', 'wn')
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,16 +43,16 @@ web = [
     "starlette",
 ]
 test = [
-    "pytest",
     "mypy",
-    "flake8",
     "nox",
+    "pytest",
+    "ruff",
     # typing stubs
     'types-requests',
 ]
 doc = [
-    "sphinx",
     "furo",
+    "sphinx",
     "sphinx-copybutton",
 ]
 editor = [
@@ -63,3 +63,21 @@ editor = [
 homepage = "https://github.com/goodmami/wn"
 documentation = "https://wn.readthedocs.io"
 changelog = "https://github.com/goodmami/wn/blob/main/CHANGELOG.md"
+
+[tool.ruff]
+select = [
+  "B",      # flake8-bugbear
+  "C90",    # McCabe cyclomatic complexity
+  "E",      # pycodestyle
+  "F",      # Pyflakes
+  "W",      # pycodestyle
+]
+ignore = [
+  "B007",
+  "B028",
+  "B904",
+]
+target-version = "py37"
+
+[tool.ruff.per-file-ignores]
+"docs/conf.py" = ["E402"]


### PR DESCRIPTION
[Ruff](https://beta.ruff.rs/) supports [over 600 lint rules](https://beta.ruff.rs/docs/rules) and can be used to replace [Flake8](https://pypi.org/project/flake8/) (plus dozens of plugins), [isort](https://pypi.org/project/isort/), [pydocstyle](https://pypi.org/project/pydocstyle/), [yesqa](https://github.com/asottile/yesqa), [eradicate](https://pypi.org/project/eradicate/), [pyupgrade](https://pypi.org/project/pyupgrade/), and [autoflake](https://pypi.org/project/autoflake/), all while executing (in Rust) tens or hundreds of times faster than any individual tool.