### PR TITLE
Don't assume id on form elements for WN-LMF 1.2+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,14 @@
 
 * Support for WN-LMF 1.2 and 1.3 ([#200])
 
+## Fixed
+
+* Don't assume 'id' on form elements in WN-LMF 1.2+ ([#207])
+
 ## Maintenance
 
 * Switched packaging from flit to Hatch ([#201])
+* Updated dependencies, CI warnings, old workarounds ([#203])
 
 
 ## [v0.9.5]
@@ -659,3 +664,5 @@ abandoned, but this is an entirely new codebase.
 [#200]: https://github.com/goodmami/wn/issues/200
 [#201]: https://github.com/goodmami/wn/issues/201
 [#202]: https://github.com/goodmami/wn/issues/202
+[#203]: https://github.com/goodmami/wn/issues/203
+[#207]: https://github.com/goodmami/wn/issues/207

--- a/tests/data/mini-lmf-1.3.xml
+++ b/tests/data/mini-lmf-1.3.xml
@@ -48,7 +48,6 @@ nodes with text content.
       </Definition>
     </Synset>
 
-
     <Synset id="test-ws-3" ili="" partOfSpeech="n">
       <Definition xml:space="preserve">
         one

--- a/wn/lmf.py
+++ b/wn/lmf.py
@@ -911,7 +911,7 @@ def _dump_syntactic_behaviour(
     version: VersionInfo
 ) -> None:
     elem = _build_syntactic_behaviour(syntactic_behaviour, version)
-    print('    ' + _tostring(elem, 2), file=out)
+    print(_tostring(elem, 2), file=out)
 
 
 def _build_syntactic_behaviour(

--- a/wn/lmf.py
+++ b/wn/lmf.py
@@ -771,7 +771,7 @@ def _build_lemma(
 
 def _build_form(form: Union[Form, ExternalForm], version: VersionInfo) -> ET.Element:
     attrib = {}
-    if version >= (1, 1) and form['id']:
+    if version >= (1, 1) and form.get('id'):
         attrib['id'] = form['id']
     if form.get('external', False):
         elem = ET.Element('ExternalForm', attrib=attrib)


### PR DESCRIPTION
This also fixes a formatting issue with SyntacticBehaviour elements.