### PR TITLE
Add Relation class and .relation_map() methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,13 @@
 ## [Unreleased][unreleased]
 
 ## Index
+
 * Added `oewn:2024` ([#221])
+
+## Added
+
+* `Sense.relation_map()` method ([#216])
+* `Synset.relation_map()` method ([#167], [#216])
 
 
 ## [v0.10.1]
@@ -681,6 +687,7 @@ abandoned, but this is an entirely new codebase.
 [#155]: https://github.com/goodmami/wn/issues/155
 [#156]: https://github.com/goodmami/wn/issues/156
 [#157]: https://github.com/goodmami/wn/issues/157
+[#167]: https://github.com/goodmami/wn/issues/167
 [#168]: https://github.com/goodmami/wn/issues/168
 [#169]: https://github.com/goodmami/wn/issues/169
 [#177]: https://github.com/goodmami/wn/issues/177
@@ -696,4 +703,5 @@ abandoned, but this is an entirely new codebase.
 [#213]: https://github.com/goodmami/wn/issues/213
 [#214]: https://github.com/goodmami/wn/issues/214
 [#215]: https://github.com/goodmami/wn/issues/215
+[#216]: https://github.com/goodmami/wn/issues/216
 [#221]: https://github.com/goodmami/wn/issues/221

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ## Added
 
+* `Relation` class ([#216])
 * `Sense.relation_map()` method ([#216])
 * `Synset.relation_map()` method ([#167], [#216])
 

--- a/docs/api/wn.rst
+++ b/docs/api/wn.rst
@@ -170,6 +170,7 @@ The Sense Class
    .. automethod:: counts
    .. automethod:: metadata
    .. automethod:: relations
+   .. automethod:: relation_map
    .. automethod:: get_related
    .. automethod:: get_related_synsets
    .. automethod:: closure
@@ -221,6 +222,7 @@ The Synset Class
    .. automethod:: holonyms
    .. automethod:: meronyms
    .. automethod:: relations
+   .. automethod:: relation_map
    .. automethod:: get_related
    .. automethod:: closure
    .. automethod:: relation_paths
@@ -251,6 +253,65 @@ The Synset Class
    .. method:: lowest_common_hypernyms(other, simulate_root=False)
 
       Shortcut for :func:`wn.taxonomy.lowest_common_hypernyms`.
+
+
+The Relation Class
+------------------
+
+The :meth:`Sense.relation_map` and :meth:`Synset.relation_map` methods
+return a dictionary mapping :class:`Relation` objects to resolved
+target senses or synsets. They differ from :meth:`Sense.relations`
+and :meth:`Synset.relations` in two main ways:
+
+1. Relation objects map 1-to-1 to their targets instead of to a list
+   of targets sharing the same relation name.
+2. Relation objects encode not just relation names, but also the
+   identifiers of sources and targets, the lexicons they came from, and
+   any metadata they have.
+
+One reason why :class:`Relation` objects are useful is for inspecting
+relation metadata, particularly in order to distinguish ``other``
+relations that differ only by the value of their ``dc:type`` metadata:
+
+>>> oewn = wn.Wordnet('oewn:2024')
+>>> alloy = oewn.senses("alloy", pos="v")[0]
+>>> alloy.relations()  # appears to only have one 'other' relation
+{'derivation': [Sense('oewn-alloy__1.27.00..')], 'other': [Sense('oewn-alloy__1.27.00..')]}
+>>> for rel in alloy.relation_map():  # but in fact there are two
+...     print(rel, rel.subtype)
+... 
+Relation('derivation', 'oewn-alloy__2.30.00..', 'oewn-alloy__1.27.00..') None
+Relation('other', 'oewn-alloy__2.30.00..', 'oewn-alloy__1.27.00..') material
+Relation('other', 'oewn-alloy__2.30.00..', 'oewn-alloy__1.27.00..') result
+
+Another reason why they are useful is to determine the source of a
+relation used in :doc:`interlingual queries <../guides/interlingual>`.
+
+>>> es = wn.Wordnet("omw-es", expand="omw-en")
+>>> mapa = es.synsets("mapa", pos="n")[0]
+>>> rel, tgt = next(iter(mapa.relation_map().items()))
+>>> rel, rel.lexicon()  # relation comes from omw-en
+(Relation('hypernym', 'omw-en-03720163-n', 'omw-en-04076846-n'), <Lexicon omw-en:1.4 [en]>)
+>>> tgt, tgt.words(), tgt.lexicon()  # target is in omw-es
+(Synset('omw-es-04076846-n'), [Word('omw-es-representación-n')], <Lexicon omw-es:1.4 [es]>)
+
+.. autoclass:: Relation
+
+   .. attribute:: name
+
+      The name of the relation. Also called the relation "type".
+
+   .. attribute:: source_id
+
+      The identifier of the source entity of the relation.
+
+   .. attribute:: target_id
+
+      The identifier of the target entity of the relation.
+
+   .. autoattribute:: subtype
+   .. automethod:: lexicon
+   .. automethod:: metadata
 
 
 The ILI Class

--- a/tests/_util_test.py
+++ b/tests/_util_test.py
@@ -1,0 +1,24 @@
+
+from wn._util import flatten, unique_list
+
+
+def test_flatten():
+    assert flatten([]) == []
+    assert flatten([[]]) == []
+    assert flatten([[], []]) == []
+    assert flatten([[[], []], [[], []]]) == [[], [], [], []]
+    assert flatten([[1]]) == [1]
+    assert flatten([[1, 2], [3, 4]]) == [1, 2, 3, 4]
+    assert flatten(["AB", "CD"]) == ["A", "B", "C", "D"]
+
+
+def test_unique_list():
+    assert unique_list([]) == []
+    assert unique_list([1]) == [1]
+    assert unique_list([1, 1, 1, 1, 1]) == [1]
+    assert unique_list([1, 1, 2, 2, 1]) == [1, 2]
+    assert unique_list([2, 1, 2, 2, 1]) == [2, 1]
+    assert unique_list("A") == ["A"]
+    assert unique_list("AAA") == ["A"]
+    assert unique_list("ABABA") == ["A", "B"]
+    assert unique_list([(1, 2), (1, 2), (2, 3)]) == [(1, 2), (2, 3)]

--- a/tests/data/mini-lmf-1.0.xml
+++ b/tests/data/mini-lmf-1.0.xml
@@ -79,6 +79,8 @@ Spanish:
       <Lemma partOfSpeech="v" writtenForm="illustrate" />
       <Sense id="test-en-illustrate-v-0003-01" synset="test-en-0003-v" >
         <SenseRelation relType="derivation" target="test-en-illustration-n-0002-01" />
+        <SenseRelation relType="other" target="test-en-illustration-n-0002-01" dc:type="result" />
+        <SenseRelation relType="other" target="test-en-illustration-n-0002-01" dc:type="event" />
       </Sense>
       <SyntacticBehaviour senses="test-en-illustrate-v-0003-01" subcategorizationFrame="Somebody ----s something" />
       <SyntacticBehaviour senses="test-en-illustrate-v-0003-01" subcategorizationFrame="Something ----s something" />

--- a/tests/relations_test.py
+++ b/tests/relations_test.py
@@ -154,6 +154,7 @@ def test_synset_relation_map():
     assert {rel.target_id for rel in relmap} == {'test-en-0001-n', 'test-en-0004-n'}
     # synset relation targets have same ids as resolved targets in same lexicon
     assert all(rel.target_id == tgt.id for rel, tgt in relmap.items())
+    assert all(rel.lexicon().id == 'test-en' for rel in relmap)
 
     # interlingual synset relation targets show original target ids
     es = wn.Wordnet('test-es', expand='test-en')
@@ -162,3 +163,4 @@ def test_synset_relation_map():
     assert {rel.name for rel in relmap} == {'hypernym', 'hyponym'}
     assert {rel.target_id for rel in relmap} == {'test-en-0001-n', 'test-en-0004-n'}
     assert all(rel.target_id != tgt.id for rel, tgt in relmap.items())
+    assert all(rel.lexicon().id == 'test-en' for rel in relmap)

--- a/wn/__init__.py
+++ b/wn/__init__.py
@@ -26,6 +26,7 @@ __all__ = (
     'synset',
     'synsets',
     'Synset',
+    'Relation',
     'ili',
     'ilis',
     'ILI',
@@ -53,6 +54,7 @@ from wn._core import (
     word, words, Word, Form, Pronunciation, Tag,
     sense, senses, Sense, Count,
     synset, synsets, Synset,
+    Relation,
     ili, ilis, ILI,
     Wordnet
 )

--- a/wn/_core.py
+++ b/wn/_core.py
@@ -1,8 +1,9 @@
 
+import enum
+import textwrap
+import warnings
 from collections.abc import Callable, Iterator, Sequence
 from typing import Optional, TypeVar
-import warnings
-import textwrap
 
 import wn
 from wn._types import (
@@ -46,10 +47,22 @@ from wn import taxonomy
 _INFERRED_SYNSET = '*INFERRED*'
 
 
+class _EntityType(str, enum.Enum):
+    """Identifies the database table of an entity."""
+    LEXICONS = 'lexicons'
+    ENTRIES = 'entries'
+    SENSES = 'senses'
+    SYNSETS = 'synsets'
+    SENSE_RELATIONS = 'sense_relations'
+    SENSE_SYNSET_RELATIONS = 'sense_synset_relations'
+    SYNSET_RELATIONS = 'synset_relations'
+    UNSET = ''
+
+
 class _DatabaseEntity:
     __slots__ = '_id',
 
-    _ENTITY_TYPE = ''
+    _ENTITY_TYPE: _EntityType = _EntityType.UNSET
 
     def __init__(self, _id: int = NON_ROWID):
         self._id = _id        # Database-internal id (e.g., rowid)
@@ -122,7 +135,7 @@ class Lexicon(_DatabaseEntity):
                  'version', 'url', 'citation', 'logo')
     __module__ = 'wn'
 
-    _ENTITY_TYPE = 'lexicons'
+    _ENTITY_TYPE = _EntityType.LEXICONS
 
     def __init__(
         self,
@@ -341,7 +354,7 @@ class Word(_LexiconElement):
     __slots__ = 'id', 'pos', '_forms'
     __module__ = 'wn'
 
-    _ENTITY_TYPE = 'entries'
+    _ENTITY_TYPE = _EntityType.ENTRIES
 
     def __init__(
         self,
@@ -513,7 +526,7 @@ class Synset(_Relatable):
     __slots__ = 'pos', '_ili'
     __module__ = 'wn'
 
-    _ENTITY_TYPE = 'synsets'
+    _ENTITY_TYPE = _EntityType.SYNSETS
 
     def __init__(
         self,
@@ -869,7 +882,7 @@ class Sense(_Relatable):
     __slots__ = '_entry_id', '_synset_id'
     __module__ = 'wn'
 
-    _ENTITY_TYPE = 'senses'
+    _ENTITY_TYPE = _EntityType.SENSES
 
     def __init__(
         self,

--- a/wn/_core.py
+++ b/wn/_core.py
@@ -1065,6 +1065,9 @@ class Sense(_Relatable):
             synset for _, synset in self._iter_sense_synset_relations(*args)
         )
 
+    def relation_map(self) -> dict[SenseRelation, 'Sense']:
+        return dict(self._iter_sense_relations())
+
     def _iter_sense_relations(self, *args: str) -> Iterator[tuple[SenseRelation, 'Sense']]:
         iterable = get_sense_relations(self._id, args, self._get_lexicon_ids())
         for relname, rellexid, relrowid, _, sid, eid, ssid, lexid, rowid in iterable:

--- a/wn/_export.py
+++ b/wn/_export.py
@@ -213,14 +213,14 @@ def _export_sense_relations(
         {'target': id,
          'relType': type,
          'meta': _export_metadata(rowid, 'sense_relations')}
-        for type, rowid, id, *_
+        for type, _, rowid, id, *_
         in get_sense_relations(sense_rowid, '*', lexids)
     ]
     relations.extend(
         {'target': id,
          'relType': type,
          'meta': _export_metadata(rowid, 'sense_synset_relations')}
-        for type, rowid, id, *_
+        for type, _, rowid, _, id, *_
         in get_sense_synset_relations(sense_rowid, '*', lexids)
     )
     return relations
@@ -304,7 +304,7 @@ def _export_synset_relations(
         {'target': id,
          'relType': type,
          'meta': _export_metadata(rowid, 'synset_relations')}
-        for type, rowid, id, *_
+        for type, _, rowid, _, id, *_
         in get_synset_relations((synset_rowid,), '*', lexids)
     ]
 

--- a/wn/_export.py
+++ b/wn/_export.py
@@ -212,14 +212,14 @@ def _export_sense_relations(
     relations: list[lmf.Relation] = [
         {'target': id,
          'relType': type,
-         'meta': metadata}
+         'meta': cast(lmf.Metadata, metadata)}
         for type, _, metadata, id, *_
         in get_sense_relations(sense_rowid, '*', lexids)
     ]
     relations.extend(
         {'target': id,
          'relType': type,
-         'meta': metadata}
+         'meta': cast(lmf.Metadata, metadata)}
         for type, _, metadata, _, id, *_
         in get_sense_synset_relations(sense_rowid, '*', lexids)
     )
@@ -303,7 +303,7 @@ def _export_synset_relations(
     return [
         {'target': id,
          'relType': type,
-         'meta': metadata}
+         'meta': cast(lmf.Metadata, metadata)}
         for type, _, metadata, _, id, *_
         in get_synset_relations((synset_rowid,), '*', lexids)
     ]

--- a/wn/_export.py
+++ b/wn/_export.py
@@ -213,7 +213,7 @@ def _export_sense_relations(
         {'target': id,
          'relType': type,
          'meta': _export_metadata(rowid, 'sense_relations')}
-        for type, _, rowid, id, *_
+        for type, _, rowid, _, id, *_
         in get_sense_relations(sense_rowid, '*', lexids)
     ]
     relations.extend(

--- a/wn/_export.py
+++ b/wn/_export.py
@@ -212,15 +212,15 @@ def _export_sense_relations(
     relations: list[lmf.Relation] = [
         {'target': id,
          'relType': type,
-         'meta': _export_metadata(rowid, 'sense_relations')}
-        for type, _, rowid, _, id, *_
+         'meta': metadata}
+        for type, _, metadata, id, *_
         in get_sense_relations(sense_rowid, '*', lexids)
     ]
     relations.extend(
         {'target': id,
          'relType': type,
-         'meta': _export_metadata(rowid, 'sense_synset_relations')}
-        for type, _, rowid, _, id, *_
+         'meta': metadata}
+        for type, _, metadata, _, id, *_
         in get_sense_synset_relations(sense_rowid, '*', lexids)
     )
     return relations
@@ -303,8 +303,8 @@ def _export_synset_relations(
     return [
         {'target': id,
          'relType': type,
-         'meta': _export_metadata(rowid, 'synset_relations')}
-        for type, _, rowid, _, id, *_
+         'meta': metadata}
+        for type, _, metadata, _, id, *_
         in get_synset_relations((synset_rowid,), '*', lexids)
     ]
 

--- a/wn/_queries.py
+++ b/wn/_queries.py
@@ -42,7 +42,17 @@ _Synset = tuple[
     int,  # lexid
     int,  # rowid
 ]
-_Synset_Relation = tuple[str, int, str, str, str, int, int]  # relname, relid, *_Synset
+_Synset_Relation = tuple[
+    str,  # rel_name
+    int,  # rel_lexid
+    int,  # rel_rowid
+    int,  # src_rowid
+    str,  # _Synset...
+    str,
+    str,
+    int,
+    int,
+]
 _Sense = tuple[
     str,  # id
     str,  # entry_id
@@ -50,7 +60,16 @@ _Sense = tuple[
     int,  # lexid
     int,  # rowid
 ]
-_Sense_Relation = tuple[str, int, str, str, str, int, int]  # relname, relid,  *_Sense
+_Sense_Relation = tuple[
+    str,  # rel_name
+    int,  # rel_lexid
+    int,  # rel_rowid
+    str,  # _Sense...
+    str,
+    str,
+    int,
+    int,
+]
 _Count = tuple[int, int]  # count, count_id
 _SyntacticBehaviour = tuple[
     str,       # id
@@ -444,10 +463,11 @@ def get_synset_relations(
     query = f'''
           WITH rt(rowid, type) AS
                (SELECT rowid, type FROM relation_types {constraint})
-        SELECT DISTINCT rel.type, rel.rowid, tgt.id, tgt.pos,
+        SELECT DISTINCT rel.type, rel.lexicon_rowid, rel.rowid,
+                        rel.source_rowid, tgt.id, tgt.pos,
                         (SELECT ilis.id FROM ilis WHERE ilis.rowid = tgt.ili_rowid),
                         tgt.lexicon_rowid, tgt.rowid
-          FROM (SELECT rt.type, target_rowid, srel.rowid
+          FROM (SELECT rt.type, lexicon_rowid, source_rowid, target_rowid, srel.rowid
                   FROM synset_relations AS srel
                   JOIN rt ON srel.type_rowid = rt.rowid
                  WHERE source_rowid IN ({_qs(source_rowids)})
@@ -590,10 +610,10 @@ def get_sense_relations(
     query = f'''
           WITH rt(rowid, type) AS
                (SELECT rowid, type FROM relation_types {constraint})
-        SELECT DISTINCT rel.type, rel.rowid,
+        SELECT DISTINCT rel.type, rel.lexicon_rowid, rel.rowid,
                         s.id, e.id, ss.id,
                         s.lexicon_rowid, s.rowid
-          FROM (SELECT rt.type, target_rowid, srel.rowid
+          FROM (SELECT rt.type, lexicon_rowid, target_rowid, srel.rowid
                   FROM sense_relations AS srel
                   JOIN rt ON srel.type_rowid = rt.rowid
                  WHERE source_rowid = ?
@@ -625,10 +645,11 @@ def get_sense_synset_relations(
     query = f'''
           WITH rt(rowid, type) AS
                (SELECT rowid, type FROM relation_types {constraint})
-        SELECT DISTINCT rel.type, rel.rowid, ss.id, ss.pos,
+        SELECT DISTINCT rel.type, rel.lexicon_rowid, rel.rowid,
+                        rel.source_rowid, ss.id, ss.pos,
                         (SELECT ilis.id FROM ilis WHERE ilis.rowid = ss.ili_rowid),
                         ss.lexicon_rowid, ss.rowid
-          FROM (SELECT rt.type, target_rowid, srel.rowid
+          FROM (SELECT rt.type, lexicon_rowid, source_rowid, target_rowid, srel.rowid
                   FROM sense_synset_relations AS srel
                   JOIN rt ON srel.type_rowid = rt.rowid
                  WHERE source_rowid = ?

--- a/wn/_util.py
+++ b/wn/_util.py
@@ -1,6 +1,6 @@
 """Non-public Wn utilities."""
 
-from collections.abc import Iterable
+from collections.abc import Iterable, Hashable
 from typing import TypeVar
 from pathlib import Path
 import hashlib
@@ -55,6 +55,15 @@ T = TypeVar('T')
 
 def flatten(iterable: Iterable[Iterable[T]]) -> list[T]:
     return [x for xs in iterable for x in xs]
+
+
+H = TypeVar('H', bound=Hashable)
+
+
+def unique_list(items: Iterable[H]) -> list[H]:
+    # use a dictionary as an order-preserving set
+    targets = {item: True for item in items}
+    return list(targets)
 
 
 def normalize_form(s: str) -> str:


### PR DESCRIPTION
This PR adds the Relation class for modeling sense and synset relations so the source lexicon, metadata, etc. of the relations are accessible. This allows for two main use cases:

1. Inspecting metadata, particularly for `other` relations
2. Identifying the source lexicon of a relation used in an interlingual query

Resolves #167
Resolves #216