### PR TITLE
Add framework for benchmarking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,16 +27,6 @@ share/python-wheels/
 *.egg
 MANIFEST
 
-# PyInstaller
-#  Usually these files are written by a python script from a template
-#  before PyInstaller builds the exe, so as to inject date/other infos into it.
-*.manifest
-*.spec
-
-# Installer logs
-pip-log.txt
-pip-delete-this-directory.txt
-
 # Unit test / coverage reports
 htmlcov/
 .tox/
@@ -51,55 +41,14 @@ coverage.xml
 .hypothesis/
 .pytest_cache/
 
-# Translations
-*.mo
-*.pot
-
-# Django stuff:
-*.log
-local_settings.py
-db.sqlite3
-db.sqlite3-journal
-
-# Flask stuff:
-instance/
-.webassets-cache
-
-# Scrapy stuff:
-.scrapy
+# Ruff (has its own .gitignore, but in case that ever changes...)
+.ruff_cache
 
 # Sphinx documentation
 docs/_build/
 
-# PyBuilder
-target/
-
 # Jupyter Notebook
 .ipynb_checkpoints
-
-# IPython
-profile_default/
-ipython_config.py
-
-# pyenv
-.python-version
-
-# pipenv
-#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
-#   However, in case of collaboration, if having platform-specific dependencies or dependencies
-#   having no cross-platform support, pipenv may install dependencies that don't work, or not
-#   install all needed dependencies.
-#Pipfile.lock
-
-# PEP 582; used by e.g. github.com/David-OConnor/pyflow
-__pypackages__/
-
-# Celery stuff
-celerybeat-schedule
-celerybeat.pid
-
-# SageMath parsed files
-*.sage.py
 
 # Environments
 .env
@@ -110,23 +59,16 @@ ENV/
 env.bak/
 venv.bak/
 
-# Spyder project settings
-.spyderproject
-.spyproject
-
-# Rope project settings
-.ropeproject
-
-# mkdocs documentation
-/site
-
 # mypy
 .mypy_cache/
 .dmypy.json
 dmypy.json
 
-# Pyre type checker
-.pyre/
-
 # PyCharm
 .idea/
+
+# VS Code
+.vscode/
+
+# benchmarking results
+.benchmarks/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased][unreleased]
 
+## Added
+
+* `wn.add_lexical_resource()` to add result of `wn.lmf.load()` to
+  database rather than from a file (pertinent to [#98])
+* `bench/` directory with benchmark tests ([#98])
+
 
 ## [v0.11.0]
 
@@ -675,6 +681,7 @@ abandoned, but this is an entirely new codebase.
 [#93]: https://github.com/goodmami/wn/issues/93
 [#95]: https://github.com/goodmami/wn/issues/95
 [#97]: https://github.com/goodmami/wn/issues/97
+[#98]: https://github.com/goodmami/wn/issues/98
 [#99]: https://github.com/goodmami/wn/issues/99
 [#104]: https://github.com/goodmami/wn/issues/104
 [#105]: https://github.com/goodmami/wn/issues/105

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,7 @@ Thanks for helping to make Wn better!
 - Documentation framework: [Sphinx](https://www.sphinx-doc.org/)
 - Docstring style: [Google Python Style Guide](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings) (via [sphinx.ext.napoleon](https://www.sphinx-doc.org/en/master/usage/extensions/napoleon.html))
 - Unit/regression testing: [pytest](https://pytest.org/)
+- Benchmarking: [pytest-benchmark](https://pytest-benchmark.readthedocs.io/)
 - Packaging framework: [Hatch](https://hatch.pypa.io/)
 - Coding style: [PEP-8](https://www.python.org/dev/peps/pep-0008/) (via [Ruff](https://beta.ruff.rs/docs/))
 - Type checking: [Mypy](http://mypy-lang.org/)
@@ -80,6 +81,7 @@ $ hatch shell           # activate a Wn virtual environment
 $ hatch fmt --check     # lint the code and check code style
 $ hatch run mypy:check  # type check with mypy
 $ hatch test            # run unit tests
+$ hatch test bench      # run benchmarks
 $ hatch build           # build a source distribution and wheel
 $ hatch publish         # publish build artifacts to PyPI
 ```

--- a/bench/README.md
+++ b/bench/README.md
@@ -1,0 +1,28 @@
+# Wn Benchmarking
+
+This directory contains code and data for running benchmarks for
+Wn. The benchmarks are implemented using
+[pytest-benchmarks](https://github.com/ionelmc/pytest-benchmark/), so
+they are run using pytest as follows (from the top-level project
+directory):
+
+```console
+$ hatch test bench/  # run the benchmarks
+$ hatch test bench/ --benchmark-autosave  # run benchmarks and store results
+$ hatch test bench/ --benchmark-compare  # run benchmarks and compare to stored result
+$ hatch test -- --help  # get help on options (look for those prefixed `--benchmark-`)
+```
+
+Notes:
+
+* The tests are not exhaustive; when making a change that may affect
+  performance, consider making a new test if one doesn't exist
+  already. It would be helpful to check in the test to Git, but not
+  the benchmark results since those are dependent on the machine.
+* Benchmark the code before and after the changes. Store the results
+  locally for comparison.
+* Ensure the testing environment has a steady load (wait for
+  long-running processes to finish, close any active web browser tabs,
+  etc.) prior to and while running the test.
+* Expect high variance for IO-bound tasks.
+

--- a/bench/conftest.py
+++ b/bench/conftest.py
@@ -1,0 +1,171 @@
+import tempfile
+from collections.abc import Iterator
+from itertools import product, cycle
+from pathlib import Path
+
+import pytest
+
+import wn
+from wn import lmf
+
+
+@pytest.fixture
+def clean_db():
+
+    def clean_db():
+        wn.remove("*")
+        dummy_lex = lmf.Lexicon(
+            id="dummy",
+            version="1",
+            label="placeholder to initialize the db",
+            language="zxx",
+            email="",
+            license="",
+        )
+        wn.add_lexical_resource(
+            lmf.LexicalResource(lmf_version="1.3", lexicons=[dummy_lex])
+        )
+
+    return clean_db
+
+
+@pytest.fixture(scope="session")
+def datadir():
+    return Path(__file__).parent.parent / "tests" / "data"
+
+
+@pytest.fixture(scope="session")
+def mini_lmf_1_0(datadir):
+    return datadir / "mini-lmf-1.0.xml"
+
+
+@pytest.fixture(scope="session")
+def empty_db_dir():
+    with tempfile.TemporaryDirectory("wn_data_empty") as dir:
+        yield Path(dir)
+
+
+@pytest.fixture
+def empty_db(monkeypatch, empty_db_dir, clean_db):
+    with monkeypatch.context() as m:
+        m.setattr(wn.config, "data_directory", empty_db_dir)
+        clean_db()
+        yield
+
+
+@pytest.fixture(scope="session")
+def mock_lmf():
+    synsets: list[lmf.Synset] = [
+       * _make_synsets("n", 20000),
+       * _make_synsets("v", 10000),
+       * _make_synsets("a", 2000),
+       * _make_synsets("r", 1000),
+    ]
+    entries = _make_entries(synsets)
+    lexicon = lmf.Lexicon(
+        id="mock",
+        version="1",
+        label="",
+        language="zxx",
+        email="",
+        license="",
+        entries=entries,
+        synsets=synsets,
+    )
+    return lmf.LexicalResource(lmf_version="1.3", lexicons=[lexicon])
+
+
+@pytest.fixture(scope="session")
+def mock_db_dir(mock_lmf):
+    with tempfile.TemporaryDirectory("wn_data_empty") as dir:
+        old_data_dir = wn.config.data_directory
+        wn.config.data_directory = dir
+        wn.add_lexical_resource(mock_lmf, progress_handler=None)
+        wn.config.data_directory = old_data_dir
+        yield Path(dir)
+        # close any open DB connections before teardown
+        for conn in wn._db.pool.values():
+            conn.close()
+
+
+@pytest.fixture
+def mock_db(monkeypatch, mock_db_dir):
+    with monkeypatch.context() as m:
+        m.setattr(wn.config, "data_directory", mock_db_dir)
+        yield
+
+
+def _make_synsets(pos: str, n: int) -> list[lmf.Synset]:
+    synsets: list[lmf.Synset] = [
+        lmf.Synset(
+            id=f"{i}-{pos}",
+            ili="",
+            partOfSpeech=pos,
+            relations=[],
+            meta={},
+        )
+        for i in range(1, n+1)
+    ]
+    # add relations for nouns and verbs
+    if pos in "nv":
+        total = len(synsets)
+        tgt_i = 1  # index of next target synset
+        n = cycle([2])  # how many targets to relate
+        for cur_i in range(total):
+            if tgt_i <= cur_i:
+                tgt_i = cur_i + 1
+            source = synsets[cur_i]
+            for cur_k in range(tgt_i, tgt_i + next(n)):
+                if cur_k >= total:
+                    break
+                target = synsets[cur_k]
+                source["relations"].append(
+                    lmf.Relation(target=target["id"], relType="hyponym", meta={})
+                )
+                target["relations"].append(
+                    lmf.Relation(target=source["id"], relType="hypernym", meta={})
+                )
+            tgt_i = cur_k + 1
+
+    return synsets
+
+
+def _words() -> Iterator[str]:
+    consonants = "kgtdpbfvszrlmnhw"
+    vowels = "aeiou"
+    while True:
+        yield from map("".join, product(consonants, vowels, consonants, vowels))
+
+
+def _make_entries(synsets: list[lmf.Synset]) -> list[lmf.LexicalEntry]:
+    words = _words()
+    member_count = cycle(range(1, 4))  # 1, 2, or 3 synset members
+    entries: dict[str, lmf.LexicalEntry] = {}
+    prev_synsets: list[lmf.Synset] = []
+    for synset in synsets:
+        ssid = synset["id"]
+        pos = synset["partOfSpeech"]
+
+        for _ in range(next(member_count)):
+            word = next(words)
+            senses = [lmf.Sense(id=f"{word}-{ssid}", synset=ssid, meta={})]
+            # add some polysemy
+            if prev_synsets:
+                ssid2 = prev_synsets.pop()["id"]
+                senses.append(lmf.Sense(id=f"{word}-{ssid2}", synset=ssid2, meta={}))
+            eid = f"{word}-{pos}"
+            if eid not in entries:
+                entries[eid] = lmf.LexicalEntry(
+                    id=eid,
+                    lemma=lmf.Lemma(
+                        writtenForm=word,
+                        partOfSpeech=pos,
+                    ),
+                    senses=[],
+                    meta={},
+                )
+            entries[eid]["senses"].extend(senses)
+
+        prev_synsets.append(synset)
+
+    return list(entries.values())

--- a/bench/test_bench.py
+++ b/bench/test_bench.py
@@ -1,0 +1,50 @@
+import wn
+from wn import lmf
+
+import pytest
+
+
+@pytest.mark.benchmark(group="lmf.load", warmup=True)
+def test_load(mini_lmf_1_0, benchmark):
+    benchmark(lmf.load, mini_lmf_1_0)
+
+
+@pytest.mark.benchmark(group="wn.add_lexical_resource")
+@pytest.mark.usefixtures('empty_db')
+def test_add_lexical_resource(mock_lmf, benchmark):
+    # TODO: when pytest-benchmark's teardown option is released, use
+    # that here with more rounds
+    benchmark.pedantic(
+        wn.add_lexical_resource,
+        args=(mock_lmf,),
+        # teardown=clean_db,
+        iterations=1,
+        rounds=1,
+    )
+
+
+@pytest.mark.benchmark(group="wn.add_lexical_resource")
+@pytest.mark.usefixtures('empty_db')
+def test_add_lexical_resource_no_progress(mock_lmf, benchmark):
+    # TODO: when pytest-benchmark's teardown option is released, use
+    # that here with more rounds
+    benchmark.pedantic(
+        wn.add_lexical_resource,
+        args=(mock_lmf,),
+        kwargs={"progress_handler": None},
+        # teardown=clean_db,
+        iterations=1,
+        rounds=1,
+    )
+
+
+@pytest.mark.benchmark(group="primary queries")
+@pytest.mark.usefixtures('mock_db')
+def test_synsets(mock_db, benchmark):
+    benchmark(wn.synsets)
+
+
+@pytest.mark.benchmark(group="primary queries")
+@pytest.mark.usefixtures('mock_db')
+def test_words(mock_db, benchmark):
+    benchmark(wn.words)

--- a/docs/api/wn.rst
+++ b/docs/api/wn.rst
@@ -10,6 +10,7 @@ Project Management Functions
 
 .. autofunction:: download
 .. autofunction:: add
+.. autofunction:: add_lexical_resource
 .. autofunction:: remove
 .. autofunction:: export
 .. autofunction:: projects

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,11 @@ exclude = [
   "/.github",
 ]
 
+[tool.hatch.envs.hatch-test]
+extra-dependencies = [
+  "pytest-benchmark",
+]
+
 [tool.hatch.envs.mypy]
 dependencies = [
   "mypy",

--- a/tests/db_test.py
+++ b/tests/db_test.py
@@ -6,6 +6,7 @@ import tempfile
 import pytest
 
 import wn
+from wn import lmf
 
 
 @pytest.mark.usefixtures('mini_db')
@@ -65,3 +66,18 @@ def test_remove_extension(mini_lmf_1_0, mini_lmf_1_1):
         # close any open DB connections before teardown
         for conn in wn._db.pool.values():
             conn.close()
+
+
+def test_add_lexical_resource(mini_lmf_1_0, mini_lmf_1_1):
+    with tempfile.TemporaryDirectory('wn_data_add_lexical_resource') as dir:
+        old_data_dir = wn.config.data_directory
+        wn.config.data_directory = dir
+        wn.add_lexical_resource(lmf.load(mini_lmf_1_0))
+        assert len(wn.lexicons()) == 2
+        wn.add_lexical_resource(lmf.load(mini_lmf_1_1))
+        assert len(wn.lexicons()) == 4
+        wn.config.data_directory = old_data_dir
+        # close any open DB connections before teardown
+        for conn in wn._db.pool.values():
+            conn.close()
+

--- a/tests/lmf_test.py
+++ b/tests/lmf_test.py
@@ -12,6 +12,41 @@ def test_is_lmf(datadir):
     assert lmf.is_lmf(datadir / 'mini-lmf-1.1.xml')
 
 
+def test_scan_lexicons(datadir):
+    assert lmf.scan_lexicons(datadir / 'mini-lmf-1.0.xml') == [
+        {
+            'id': 'test-en',
+            'version': '1',
+            'label': 'Testing English WordNet',
+            'extends': None,
+        },
+        {
+            'id': 'test-es',
+            'version': '1',
+            'label': 'Testing Spanish WordNet',
+            'extends': None,
+        },
+    ]
+
+    assert lmf.scan_lexicons(datadir / 'mini-lmf-1.1.xml') == [
+        {
+            'id': 'test-ja',
+            'version': '1',
+            'label': 'Testing Japanese WordNet',
+            'extends': None,
+        },
+        {
+            'id': 'test-en-ext',
+            'version': '1',
+            'label': 'Testing English Extension',
+            'extends': {
+                'id': 'test-en',
+                'version': '1',
+            },
+        },
+    ]
+
+
 def test_load_1_0(mini_lmf_1_0):
     resource = lmf.load(mini_lmf_1_0)
     lexicons = resource['lexicons']

--- a/wn/__init__.py
+++ b/wn/__init__.py
@@ -8,6 +8,7 @@ __all__ = (
     'Wordnet',
     'download',
     'add',
+    'add_lexical_resource',
     'remove',
     'export',
     'projects',
@@ -45,7 +46,7 @@ from wn._exceptions import (
     WnWarning,
 )
 from wn._config import config  # noqa: F401
-from wn._add import add, remove
+from wn._add import add, add_lexical_resource, remove
 from wn._export import export
 from wn._download import download
 from wn._core import (

--- a/wn/__main__.py
+++ b/wn/__main__.py
@@ -9,6 +9,7 @@ import wn
 from wn.project import iterpackages
 from wn import lmf
 from wn.validate import validate
+from wn._util import format_lexicon_specifier
 
 
 def _download(args):
@@ -45,7 +46,7 @@ def _validate(args):
     for package in iterpackages(args.FILE):
         resource = lmf.load(package.resource_file())
         for lexicon in resource['lexicons']:
-            spec = f'{lexicon["id"]}:{lexicon["version"]}'
+            spec = format_lexicon_specifier(lexicon["id"], lexicon["version"])
             print(f'{spec:<20}', end='')
             report = validate(lexicon, select=selectseq)
             if not any(check.get('items', []) for check in report.values()):

--- a/wn/_add.py
+++ b/wn/_add.py
@@ -14,14 +14,14 @@ from wn._types import AnyPath
 from wn.constants import _WORDNET, _ILI
 from wn._db import connect
 from wn._queries import find_lexicons, get_lexicon_extensions, get_lexicon
-from wn._util import normalize_form
+from wn._util import normalize_form, format_lexicon_specifier
 from wn.util import ProgressHandler, ProgressBar
 from wn.project import iterpackages
 from wn import lmf
 from wn import _ili
 
 
-logger = logging.getLogger('wn')
+log = logging.getLogger('wn')
 
 
 BATCH_SIZE = 1000
@@ -100,9 +100,9 @@ def add(
         progress_handler = ProgressHandler
     progress = progress_handler(message='Database')
 
-    logger.info('adding project to database')
-    logger.info('  database: %s', wn.config.database_path)
-    logger.info('  project file: %s', source)
+    log.info('adding project to database')
+    log.info('  database: %s', wn.config.database_path)
+    log.info('  project file: %s', source)
 
     try:
         for package in iterpackages(source):
@@ -121,6 +121,28 @@ def _add_lmf(
     progress: ProgressHandler,
     progress_handler: type[ProgressHandler],
 ) -> None:
+    # abort if any lexicon in *source* is already added
+    progress.flash(f'Checking {source!s}')
+    infos = lmf.scan_lexicons(source)
+    if not infos:
+        progress.flash(f'{source}: No lexicons found')
+        return
+
+    skipmap = _precheck(infos, progress)
+    if all(skipmap.values()):
+        return  # nothing to do
+
+    # all clear, try to add them
+    progress.flash(f'Reading {source!s}')
+    resource = lmf.load(source, progress_handler)
+    _add_lexical_resource(resource, skipmap, progress)
+
+
+def _add_lexical_resource(
+    resource: lmf.LexicalResource,
+    skipmap: dict[str, bool],
+    progress: ProgressHandler,
+) -> None:
     with connect() as conn:
         cur = conn.cursor()
         # these two settings increase the risk of database corruption
@@ -129,28 +151,10 @@ def _add_lmf(
         cur.execute('PRAGMA synchronous = OFF')
         cur.execute('PRAGMA journal_mode = MEMORY')
 
-        # abort if any lexicon in *source* is already added
-        progress.flash(f'Checking {source!s}')
-        all_infos = _precheck(source, cur)
-
-        if not all_infos:
-            progress.flash(f'{source}: No lexicons found')
-            return
-        for info in all_infos:
-            skip = info.get('skip', '')
-            if skip:
-                id, ver, lbl = info['id'], info['version'], info['label']
-                progress.flash(f'Skipping {id}:{ver} ({lbl}); {skip}\n')
-        if all('skip' in info for info in all_infos):
-            return
-
-        # all clear, try to add them
-        progress.flash(f'Reading {source!s}')
-        resource = lmf.load(source, progress_handler)
-
-        for lexicon, info in zip(resource['lexicons'], all_infos):
-            if 'skip' in info:
-                continue
+        for lexicon in resource['lexicons']:
+            spec = format_lexicon_specifier(lexicon["id"], lexicon["version"])
+            if skipmap[spec]:
+                continue  # _precheck() says this should be skipped
 
             progress.flash('Updating lookup tables')
             _update_lookup_tables(lexicon, cur)
@@ -160,7 +164,7 @@ def _add_lmf(
             entries: Sequence[_AnyEntry] = _entries(lexicon)
             synbhrs: Sequence[lmf.SyntacticBehaviour] = _collect_frames(lexicon)
 
-            lexid, extid = _insert_lexicon(lexicon, info, cur, progress)
+            lexid, extid = _insert_lexicon(lexicon, cur, progress)
 
             lexidmap = _build_lexid_map(lexicon, lexid, extid)
 
@@ -183,22 +187,39 @@ def _add_lmf(
             _insert_examples(synsets, lexid, lexidmap, 'synset_examples', cur, progress)
 
             progress.set(status='')  # clear type string
-            progress.flash(
-                f"Added {lexicon['id']}:{lexicon['version']} ({lexicon['label']})\n"
-            )
+            progress.flash(f"Added {spec} ({lexicon['label']})\n")
 
 
-def _precheck(source: Path, cur: sqlite3.Cursor) -> list[dict]:
+def _precheck(
+    infos: list[lmf.ScanInfo],
+    progress: ProgressHandler,
+) -> dict[str, bool]:
+    skipmap: dict[str, bool] = {}
     lexqry = 'SELECT * FROM lexicons WHERE id = :id AND version = :version'
-    infos = lmf.scan_lexicons(source)
-    for info in infos:
-        base = info.get('extends')
-        if cur.execute(lexqry, info).fetchone():
-            info['skip'] = 'already added'
-        if base and cur.execute(lexqry, base).fetchone() is None:
-            id_, ver = base['id'], base['version']
-            info['skip'] = f'base lexicon ({id_}:{ver}) not available'
-    return infos
+    with connect() as conn:
+        cur = conn.cursor()
+        for info in infos:
+            key = format_lexicon_specifier(info['id'], info['version'])
+            base = info.get('extends')
+
+            skipmap[key] = False
+            reason = ''
+
+            # can't have two lexicons with the same specifier in the db
+            if cur.execute(lexqry, info).fetchone():
+                skipmap[key] = True
+                reason = 'already added'
+
+            # can't have an extension without the base
+            elif base and cur.execute(lexqry, base).fetchone() is None:
+                skipmap[key] = True
+                base_key = format_lexicon_specifier(base['id'], base['version'])
+                reason = f"base lexicon ({base_key}) not available"
+
+            if reason:
+                progress.flash(f"Skipping {key} ({info['label']}); {reason}\n")
+
+    return skipmap
 
 
 def _sum_counts(lex: _AnyLexicon) -> int:
@@ -255,7 +276,6 @@ def _update_lookup_tables(
 
 def _insert_lexicon(
     lexicon: _AnyLexicon,
-    info: dict,
     cur: sqlite3.Cursor,
     progress: ProgressHandler
 ) -> tuple[int, int]:
@@ -893,7 +913,7 @@ def remove(
                     conn.execute('DELETE from lexicons WHERE rowid = ?', (ext_id,))
                     progress.flash(f'Removed {ext_spec}\n')
 
-                spec = f'{id}:{version}'
+                spec = format_lexicon_specifier(id, version)
                 extra = f' (and {len(extensions)} extension(s))' if extensions else ''
                 progress.set(status=f'{spec}', count=0)
                 conn.execute('DELETE from lexicons WHERE rowid = ?', (rowid,))
@@ -908,7 +928,7 @@ def _find_all_extensions(rowid: int) -> list[tuple[int, str]]:
     exts: list[tuple[int, str]] = []
     for ext_id in get_lexicon_extensions(rowid):
         lexinfo = get_lexicon(ext_id)
-        exts.append((ext_id, f'{lexinfo[1]}:{lexinfo[6]}'))
+        exts.append((ext_id, format_lexicon_specifier(lexinfo[1], lexinfo[6])))
     return exts
 
 

--- a/wn/_config.py
+++ b/wn/_config.py
@@ -13,7 +13,7 @@ import tomli
 from wn import ConfigurationError, ProjectError
 from wn._types import AnyPath
 from wn.constants import _WORDNET
-from wn._util import short_hash
+from wn._util import short_hash, format_lexicon_specifier
 
 # The index file is a project file of Wn
 with as_file(files('wn') / 'index.toml') as index_file:
@@ -124,7 +124,8 @@ class WNConfig:
         elif error and not url:
             version_data = {'error': error}
         elif url and error:
-            raise ConfigurationError(f'{id}:{version} specifies both url and redirect')
+            spec = format_lexicon_specifier(id, version)
+            raise ConfigurationError(f'{spec} specifies both url and redirect')
         else:
             version_data = {}
         if license:
@@ -220,8 +221,9 @@ class WNConfig:
                 )
             for version, info in project.get('versions', {}).items():
                 if 'url' in info and 'error' in project:
+                    spec = format_lexicon_specifier(id, version)
                     raise ConfigurationError(
-                        f'{id}:{version} url specified with default error'
+                        f'{spec} url specified with default error'
                     )
                 self.add_project_version(
                     id,

--- a/wn/_db.py
+++ b/wn/_db.py
@@ -10,7 +10,7 @@ import logging
 
 import wn
 from wn._types import AnyPath
-from wn._util import short_hash
+from wn._util import short_hash, format_lexicon_specifier
 
 
 logger = logging.getLogger('wn')
@@ -114,7 +114,10 @@ def _check_schema_compatibility(conn: sqlite3.Connection, dbpath: Path) -> None:
         raise wn.DatabaseError(msg) from exc
     else:
         if specs:
-            installed = '\n  '.join(f'{id}:{ver}' for id, ver in specs)
+            installed = '\n  '.join(
+                format_lexicon_specifier(id, ver)
+                for id, ver in specs
+            )
             msg += f" Lexicons currently installed:\n  {installed}"
         else:
             msg += ' No lexicons are currently installed.'

--- a/wn/_util.py
+++ b/wn/_util.py
@@ -68,3 +68,7 @@ def unique_list(items: Iterable[H]) -> list[H]:
 
 def normalize_form(s: str) -> str:
     return ''.join(c for c in normalize('NFKD', s.lower()) if not combining(c))
+
+
+def format_lexicon_specifier(id: str, version: str) -> str:
+    return f"{id}:{version}"


### PR DESCRIPTION
This PR adds a framework for future benchmarks, based on pytest-benchmark. It only adds a few benchmarks as an example, and future changes to Wn may add their own benchmarks during development.

This PR also makes some changes to better support benchmarking, such as adding a `wn.add_lexical_resource()` function that adds an in-memory LMF lexical resource (as from `wn.load()`) without having to read a file.