### PR TITLE
Allow word IDs on synset members list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased][unreleased]
 
+## Changed
+
+* `wn.add()` allows synset members to be lexical entry IDs for rank
+  calculations ([#255])
+
 
 ## [v0.12.0]
 
@@ -771,3 +776,4 @@ abandoned, but this is an entirely new codebase.
 [#241]: https://github.com/goodmami/wn/issues/241
 [#246]: https://github.com/goodmami/wn/issues/246
 [#250]: https://github.com/goodmami/wn/issues/250
+[#255]: https://github.com/goodmami/wn/issues/255

--- a/tests/data/sense-member-order.xml
+++ b/tests/data/sense-member-order.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE LexicalResource SYSTEM "http://globalwordnet.github.io/schemas/WN-LMF-1.1.dtd">
+<LexicalResource xmlns:dc="http://purl.org/dc/elements/1.1/">
+
+<!-- duplicate ID in synsets -->
+
+  <Lexicon id="test"
+           label="Testing Sense Member Orders"
+           language="en"
+           email="maintainer@example.com"
+           license="https://creativecommons.org/licenses/by/4.0/"
+           version="1">
+
+    <LexicalEntry id="test-foo-n">
+      <Lemma partOfSpeech="n" writtenForm="foo" />
+      <Sense id="test-01-foo-n" synset="test-01-n" />
+      <Sense id="test-02-foo-n" synset="test-02-n" />
+    </LexicalEntry>
+
+    <LexicalEntry id="test-bar-n">
+      <Lemma partOfSpeech="n" writtenForm="bar" />
+      <Sense id="test-02-bar-n" synset="test-02-n" />
+      <Sense id="test-01-bar-n" synset="test-01-n" />
+    </LexicalEntry>
+
+    <!-- sense IDs as members -->
+    <Synset id="test-01-n" ili="i12345" partOfSpeech="n" members="test-01-bar-n test-01-foo-n"/>
+    <!-- word IDs as members -->
+    <Synset id="test-02-n" ili="i12346" partOfSpeech="n" members="test-bar-n test-foo-n" />
+
+  </Lexicon>
+
+</LexicalResource>

--- a/tests/secondary_query_test.py
+++ b/tests/secondary_query_test.py
@@ -146,3 +146,25 @@ def test_synset_lexicalized():
 def test_synset_translate():
     assert len(wn.synset('test-en-0001-n').translate(lang='es')) == 1
     assert len(wn.synset('test-es-0001-n').translate(lang='en')) == 1
+
+
+@pytest.mark.usefixtures('uninitialized_datadir')
+def test_word_sense_order(datadir):
+    wn.add(datadir / 'sense-member-order.xml')
+    assert [s.id for s in wn.word('test-foo-n').senses()] == [
+        "test-01-foo-n", "test-02-foo-n",
+    ]
+    assert [s.id for s in wn.word('test-bar-n').senses()] == [
+        "test-02-bar-n", "test-01-bar-n",
+    ]
+
+
+@pytest.mark.usefixtures('uninitialized_datadir')
+def test_synset_member_order(datadir):
+    wn.add(datadir / 'sense-member-order.xml')
+    assert [s.id for s in wn.synset('test-01-n').senses()] == [
+        "test-01-bar-n", "test-01-foo-n",
+    ]
+    assert [s.id for s in wn.synset('test-02-n').senses()] == [
+        "test-02-bar-n", "test-02-foo-n",
+    ]


### PR DESCRIPTION
The OEWN uses word IDs while OMW uses sense IDs for the synset members attribute. This meant that OEWN synset members were not being returned in the right order.

Fixes #255