### PR TITLE
Hotfix web 404

### DIFF
--- a/tests/web_test.py
+++ b/tests/web_test.py
@@ -25,7 +25,11 @@ client = TestClient(web.app)
 @pytest.mark.usefixtures('mini_db_web')
 def test_root():
     response = client.get('/')
-    assert response.status_code == 404
+    assert response.status_code == 200
+    data = response.json()
+    endpoints = data["endpoints"]
+    for endpoint_name in "/lexicons", "/words", "/senses", "/synsets", "/health":
+        assert endpoint_name in endpoints
 
 
 @pytest.mark.usefixtures('mini_db_web')

--- a/tests/web_test.py
+++ b/tests/web_test.py
@@ -33,6 +33,14 @@ def test_root():
 
 
 @pytest.mark.usefixtures('mini_db_web')
+def test_health():
+    response = client.get('/health')
+    assert response.status_code == 200
+    data = response.json()
+    assert data['status'] == 'healthy'
+
+
+@pytest.mark.usefixtures('mini_db_web')
 def test_lexicons():
     response = client.get("/lexicons")
     assert response.status_code == 200

--- a/wn/web.py
+++ b/wn/web.py
@@ -3,7 +3,7 @@
 from typing import Optional, Union
 from functools import wraps
 from urllib.parse import urlsplit, parse_qs, urlencode
-from datetime import datetime, UTC
+from datetime import datetime, timezone
 
 from starlette.applications import Starlette  # type: ignore
 from starlette.responses import JSONResponse  # type: ignore
@@ -339,7 +339,7 @@ async def index(request: Request):
 async def health_check(request: Request):
     body = {
         'status': 'healthy',
-        'timestamp': datetime.now(tz=UTC).isoformat(),
+        'timestamp': datetime.now(tz=timezone.utc).isoformat(),
         'service': 'wn.web',
     }
     return JSONResponse(body, status_code=200)

--- a/wn/web.py
+++ b/wn/web.py
@@ -1,4 +1,3 @@
-
 """Web interface for Wn databases."""
 
 from typing import Optional, Union
@@ -17,9 +16,7 @@ DEFAULT_PAGINATION_LIMIT = 50
 
 
 def paginate(proto):
-
     def paginate_wrapper(func):
-
         @wraps(func)
         async def _paginate_wrapper(request: Request) -> JSONResponse:
             url = str(request.url)
@@ -31,9 +28,11 @@ def paginate(proto):
             total = len(obj['data'])
             prev = max(0, offset - limit)
             next = offset + limit
-            last = (total//limit)*limit
+            last = (total // limit) * limit
 
-            obj['data'] = [proto(x, request) for x in obj['data'][offset:offset+limit]]
+            obj['data'] = [
+                proto(x, request) for x in obj['data'][offset : offset + limit]
+            ]
             obj.setdefault('meta', {}).update(total=total)
 
             links = {}
@@ -63,6 +62,7 @@ def replace_query_params(url: str, **params) -> str:
 
 # Wordnet-instantiation
 
+
 def _init_wordnet(
     lexicon: str = '*',
     lang: Optional[str] = None,
@@ -74,6 +74,7 @@ def _init_wordnet(
 
 # Data-making functions
 
+
 def _url_for_obj(
     request: Request,
     name: str,
@@ -84,7 +85,7 @@ def _url_for_obj(
         lexicon = obj.lexicon().specifier()
     kwargs = {
         'lexicon': lexicon,
-        name: obj.id
+        name: obj.id,
     }
     return str(request.url_for(name, **kwargs))
 
@@ -102,7 +103,7 @@ def make_lexicon(lex: wn.Lexicon, request: Request) -> dict:
             'license': lex.license,
         },
         'links': {
-            'self': str(request.url_for('lexicon', lexicon=spec))
+            'self': str(request.url_for('lexicon', lexicon=spec)),
         },
         'relationships': {
             'words': {
@@ -114,7 +115,7 @@ def make_lexicon(lex: wn.Lexicon, request: Request) -> dict:
             'senses': {
                 'links': {'related': str(request.url_for('senses', lexicon=spec))},
             },
-        }
+        },
     }
 
 
@@ -129,21 +130,25 @@ def make_word(w: wn.Word, request: Request, basic: bool = False) -> dict:
             'forms': w.forms(),
         },
         'links': {
-            'self': _url_for_obj(request, 'word', w, lexicon=lex_spec)
-        }
+            'self': _url_for_obj(request, 'word', w, lexicon=lex_spec),
+        },
     }
     if not basic:
         synsets = w.synsets()
         lex_link = str(request.url_for('lexicon', lexicon=lex_spec))
         senses_link = str(request.url_for('senses', word=w.id, lexicon=lex_spec))
-        d.update({
-            'relationships': {
-                'senses': {'links': {'related': senses_link}},
-                'synsets': {'data': [dict(type='synset', id=ss.id) for ss in synsets]},
-                'lexicon': {'links': {'related': lex_link}}
-            },
-            'included': [make_synset(ss, request, basic=True) for ss in synsets]
-        })
+        d.update(
+            {
+                'relationships': {
+                    'senses': {'links': {'related': senses_link}},
+                    'synsets': {
+                        'data': [dict(type='synset', id=ss.id) for ss in synsets]
+                    },
+                    'lexicon': {'links': {'related': lex_link}},
+                },
+                'included': [make_synset(ss, request, basic=True) for ss in synsets],
+            }
+        )
     return d
 
 
@@ -153,8 +158,8 @@ def make_sense(s: wn.Sense, request: Request, basic: bool = False) -> dict:
         'id': s.id,
         'type': 'sense',
         'links': {
-            'self': _url_for_obj(request, 'sense', s, lexicon=lex_spec)
-        }
+            'self': _url_for_obj(request, 'sense', s, lexicon=lex_spec),
+        },
     }
     if not basic:
         w = s.word()
@@ -165,12 +170,12 @@ def make_sense(s: wn.Sense, request: Request, basic: bool = False) -> dict:
         relationships: dict = {
             'word': {'links': {'related': word_link}},
             'synset': {'links': {'related': synset_link}},
-            'lexicon': {'links': {'related': lex_link}}
+            'lexicon': {'links': {'related': lex_link}},
         }
         included = []
         for relname, slist in s.relations().items():
             relationships[relname] = {
-                'data': [dict(type='sense', id=_s.id) for _s in slist]
+                'data': [dict(type='sense', id=_s.id) for _s in slist],
             }
             included.extend([make_sense(_s, request, basic=True) for _s in slist])
         d.update({'relationships': relationships, 'included': included})
@@ -187,8 +192,8 @@ def make_synset(ss: wn.Synset, request: Request, basic: bool = False) -> dict:
             'ili': ss._ili,
         },
         'links': {
-            'self': _url_for_obj(request, 'synset', ss, lexicon=lex_spec)
-        }
+            'self': _url_for_obj(request, 'synset', ss, lexicon=lex_spec),
+        },
     }
     if not basic:
         words = ss.words()
@@ -197,12 +202,12 @@ def make_synset(ss: wn.Synset, request: Request, basic: bool = False) -> dict:
         relationships: dict = {
             'members': {'links': {'related': members_link}},
             'words': {'data': [dict(type='word', id=w.id) for w in words]},
-            'lexicon': {'links': {'related': lex_link}}
+            'lexicon': {'links': {'related': lex_link}},
         }
         included = [make_word(w, request, basic=True) for w in words]
         for relname, sslist in ss.relations().items():
             relationships[relname] = {
-                'data': [dict(type='synset', id=_s.id) for _s in sslist]
+                'data': [dict(type='synset', id=_s.id) for _s in sslist],
             }
             included.extend([make_synset(_s, request, basic=True) for _s in sslist])
         d.update({'relationships': relationships, 'included': included})
@@ -210,6 +215,7 @@ def make_synset(ss: wn.Synset, request: Request, basic: bool = False) -> dict:
 
 
 # Route handlers
+
 
 @paginate(make_lexicon)
 async def lexicons(request):
@@ -322,8 +328,11 @@ async def synset(request):
 
 
 async def index(request: Request):
-    endpoints = {route.path: str(request.url_for(route.name))
-                 for route in routes if len(route.param_convertors) == 0}
+    endpoints = {
+        route.path: str(request.url_for(route.name))
+        for route in routes
+        if len(route.param_convertors) == 0
+    }
     return JSONResponse({'endpoints': endpoints})
 
 
@@ -334,6 +343,7 @@ async def health_check(request: Request):
         'service': 'wn.web',
     }
     return JSONResponse(body, status_code=200)
+
 
 routes = [
     Route('/', endpoint=index),


### PR DESCRIPTION
PR #268 added an endpoint for `/` but the corresponding unit test was not updated and it was still checking for a 404. The test is now updated to expect a 200 response with a small set of known endpoints.

Secondly, the module used `datetime.UTC`, which is only available from Python 3.11. The `datetime.timezone` object is more compatible.

This PR also adds a unit test for the `/health` endpoint and reformats the `web.py` file according to Ruff formatting rules.