### PR TITLE
Fixed doc string for taxonomy depth

### DIFF
--- a/wn/taxonomy.py
+++ b/wn/taxonomy.py
@@ -60,7 +60,7 @@ def leaves(wordnet: 'Wordnet', pos: Optional[str] = None) -> list['Synset']:
 
 def taxonomy_depth(wordnet: 'Wordnet', pos: str) -> int:
     """Return the maximum depth of the taxonomy for the given part of speech.
-    
+
     Arguments:
 
         wordnet: The wordnet for which the taxonomy depth will be


### PR DESCRIPTION
Fixed!  This fixes #290:
new docstring is:

````python
def taxonomy_depth(wordnet: 'Wordnet', pos: str) -> int:
    """Return the maximum depth of the taxonomy for the given part of speech.
```    

